### PR TITLE
valid email field widget

### DIFF
--- a/owl/static/src/components/valid_email_field/valid_email_field.js
+++ b/owl/static/src/components/valid_email_field/valid_email_field.js
@@ -1,0 +1,21 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry"
+import { EmailField } from "@web/views/fields/email/email_field"
+
+class ValidEmailField extends EmailField {
+    setup(){
+        super.setup()
+        console.log("Email Field Inherited in Form View of Contacts App")
+        console.log(this.props)
+    }
+
+    get isValidEmail(){
+        let reg_expr = /\S+@\S+\.\S+/;
+        return reg_expr.test(this.props.value)
+    }
+}
+ValidEmailField.template = "owl.ValidEmailField"
+ValidEmailField.supportedTypes = ["char"]
+
+registry.category("fields").add("valid_email", ValidEmailField)

--- a/owl/static/src/components/valid_email_field/valid_email_field.xml
+++ b/owl/static/src/components/valid_email_field/valid_email_field.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="owl.ValidEmailField" t-inherit="web.EmailField" owl="1">
+        <xpath expr="." position="inside">
+            <span class="text-warning" t-if="!isValidEmail">!! Invalid Email !!</span>
+        </xpath>
+
+        <!-- EMAIL FAVICON -->
+        <xpath expr="//input" position="after">
+            <a t-if="props.value and isValidEmail" t-att-href="'mailto:'+props.value" class="ms-3 d-inline-flex align-items-center">
+                <i class="fa fa-envelope" data-tooltip="Send Email" aria-label="Send Email"></i>
+            </a>
+        </xpath>
+    </t>
+</templates>

--- a/owl/views/res_partner.xml
+++ b/owl/views/res_partner.xml
@@ -31,6 +31,10 @@
             <xpath expr="//form" position="attributes">
                 <attribute name="js_class">res_partner_form_view</attribute>
             </xpath>
+
+            <field name="email" position="attributes">
+                <attribute name="widget">valid_email</attribute>
+            </field>
         </field>
     </record>
 </data>


### PR DESCRIPTION
widget provides a warning if user tries to save an invalid email address. widget also includes email favicon that user can click to open a `New Email` to send to contact 